### PR TITLE
Refactor/22 auth service srp

### DIFF
--- a/src/main/java/com/market/openmarket/common/util/UserValidator.java
+++ b/src/main/java/com/market/openmarket/common/util/UserValidator.java
@@ -6,6 +6,7 @@ import com.market.openmarket.common.exception.DuplicateUserException;
 import com.market.openmarket.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -13,6 +14,7 @@ public class UserValidator {
 
     private final UserRepository userRepository;
 
+    @Transactional(readOnly = true)
     public void validateDuplicate(UserSignUpRequestDto requestDto) {
         if (userRepository.existsByEmail(requestDto.getEmail())) {
             throw new DuplicateUserException("이미 사용 중인 이메일입니다.");
@@ -25,6 +27,7 @@ public class UserValidator {
         }
     }
 
+    @Transactional(readOnly = true)
     public void validateDuplicateForUpdate(Long userId, UserUpdateRequestDto requestDto) {
         if (requestDto.getNickname() != null) {
             userRepository.findByNickname(requestDto.getNickname())
@@ -39,6 +42,14 @@ public class UserValidator {
                     .ifPresent(user -> {
                         throw new DuplicateUserException("이미 사용 중인 전화번호입니다.");
                     });
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public void checkEmailExists(String email) {
+        boolean isExist = userRepository.existsByEmail(email);
+        if (!isExist) {
+            throw new IllegalArgumentException("존재하지 않는 이메일입니다.");
         }
     }
 }

--- a/src/main/java/com/market/openmarket/domain/auth/AuthServiceImpl.java
+++ b/src/main/java/com/market/openmarket/domain/auth/AuthServiceImpl.java
@@ -1,15 +1,14 @@
 package com.market.openmarket.domain.auth;
 
-import com.market.openmarket.domain.auth.entity.RefreshToken;
-import com.market.openmarket.domain.auth.dto.UserLogInRequestDto;
-import com.market.openmarket.domain.auth.dto.UserSignUpRequestDto;
-import com.market.openmarket.domain.auth.dto.UserLogInResponseDto;
 import com.market.openmarket.common.dto.UserResponseDto;
-import com.market.openmarket.domain.user.entity.User;
-import com.market.openmarket.domain.user.UserRepository;
-import com.market.openmarket.common.util.UserValidator;
+import com.market.openmarket.domain.auth.dto.UserLogInRequestDto;
+import com.market.openmarket.domain.auth.dto.UserLogInResponseDto;
+import com.market.openmarket.domain.auth.dto.UserSignUpRequestDto;
+import com.market.openmarket.domain.auth.entity.RefreshToken;
 import com.market.openmarket.domain.auth.util.bcrypt.PasswordEncoder;
 import com.market.openmarket.domain.auth.util.jwt.JwtProvider;
+import com.market.openmarket.domain.user.UserService;
+import com.market.openmarket.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,37 +20,23 @@ import java.time.ZoneId;
 @RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
 
-    private final UserRepository userRepository;
+    private final UserService userService;
     private final PasswordEncoder passwordEncoder;
-    private final UserValidator userValidator;
     private final JwtProvider jwtProvider;
     private final RefreshTokenRepository refreshTokenRepository;
 
     @Transactional
     public UserResponseDto signUp(UserSignUpRequestDto requestDto) {
-        userValidator.validateDuplicate(requestDto);
         String hashedPwd = passwordEncoder.hash(requestDto.getPwd());
+        requestDto.setPwd(hashedPwd);
 
-        User user = User.builder()
-                .email(requestDto.getEmail())
-                .pwd(hashedPwd)
-                .name(requestDto.getName())
-                .phone(requestDto.getPhone())
-                .nickname(requestDto.getNickname())
-                .address(requestDto.getAddress())
-                .isDeleted(false)
-                .type(requestDto.getType())
-                .build();
-
-        User savedUser = userRepository.save(user);
-
+        User savedUser = userService.createUser(requestDto);
         return UserResponseDto.fromEntity(savedUser);
     }
 
     @Transactional
     public UserLogInResponseDto logIn(UserLogInRequestDto requestDto) {
-        User user = userRepository.findByEmail(requestDto.getEmail())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        User user = userService.findByEmail(requestDto.getEmail());
 
         boolean isValid = passwordEncoder.checkPwd(requestDto.getPwd(), user.getPwd());
         if (!isValid) {
@@ -61,7 +46,6 @@ public class AuthServiceImpl implements AuthService {
         JwtToken accessToken = jwtProvider.generateAccessToken(user);
         JwtToken refreshToken = jwtProvider.generateRefreshToken(user);
 
-        // TODO: 리팩터링 시 JPA AttributeConverter 적용하기
         LocalDateTime issuedAt = LocalDateTime.ofInstant(refreshToken.getIssuedAt().toInstant(), ZoneId.of("UTC"));
         LocalDateTime expiresAt = LocalDateTime.ofInstant(refreshToken.getExpiration().toInstant(), ZoneId.of("UTC"));
 
@@ -70,12 +54,10 @@ public class AuthServiceImpl implements AuthService {
                         .userId(user.getId()).build()
                 );
 
-        // 토큰을 가진 유저가 새로 로그인한다면 토큰 값과 발행일자, 만료일자 새로 세팅
         refreshTokenEntity.setToken(refreshToken.getToken());
         refreshTokenEntity.setIssuedAt(issuedAt);
         refreshTokenEntity.setExpiresAt(expiresAt);
 
-        // 신규 엔티티의 경우 JPA DirtyChecking 적용 안됨. 명시적 save() 호출
         refreshTokenRepository.save(refreshTokenEntity);
 
         return UserLogInResponseDto.builder()

--- a/src/main/java/com/market/openmarket/domain/auth/AuthServiceImpl.java
+++ b/src/main/java/com/market/openmarket/domain/auth/AuthServiceImpl.java
@@ -36,7 +36,7 @@ public class AuthServiceImpl implements AuthService {
 
     @Transactional
     public UserLogInResponseDto logIn(UserLogInRequestDto requestDto) {
-        User user = userService.findByEmail(requestDto.getEmail());
+        User user = userService.findByEmailOrFail(requestDto.getEmail());
 
         boolean isValid = passwordEncoder.checkPwd(requestDto.getPwd(), user.getPwd());
         if (!isValid) {

--- a/src/main/java/com/market/openmarket/domain/user/UserService.java
+++ b/src/main/java/com/market/openmarket/domain/user/UserService.java
@@ -11,7 +11,7 @@ public interface UserService {
 
     User createUser(UserSignUpRequestDto requestDto);
 
-    User findByEmail(String email);
+    User findByEmailOrFail(String email);
 
     UserResponseDto getUser(Long id);
 

--- a/src/main/java/com/market/openmarket/domain/user/UserService.java
+++ b/src/main/java/com/market/openmarket/domain/user/UserService.java
@@ -1,12 +1,17 @@
 package com.market.openmarket.domain.user;
 
-import com.market.openmarket.domain.user.entity.User;
-import com.market.openmarket.domain.user.dto.UserUpdateRequestDto;
 import com.market.openmarket.common.dto.UserResponseDto;
+import com.market.openmarket.domain.auth.dto.UserSignUpRequestDto;
+import com.market.openmarket.domain.user.dto.UserUpdateRequestDto;
+import com.market.openmarket.domain.user.entity.User;
 
 public interface UserService {
 
     User findByIdOrFail(Long id);
+
+    User createUser(UserSignUpRequestDto requestDto);
+
+    User findByEmail(String email);
 
     UserResponseDto getUser(Long id);
 

--- a/src/main/java/com/market/openmarket/domain/user/UserServiceImpl.java
+++ b/src/main/java/com/market/openmarket/domain/user/UserServiceImpl.java
@@ -1,9 +1,10 @@
 package com.market.openmarket.domain.user;
 
-import com.market.openmarket.domain.user.entity.User;
-import com.market.openmarket.domain.user.dto.UserUpdateRequestDto;
 import com.market.openmarket.common.dto.UserResponseDto;
 import com.market.openmarket.common.util.UserValidator;
+import com.market.openmarket.domain.auth.dto.UserSignUpRequestDto;
+import com.market.openmarket.domain.user.dto.UserUpdateRequestDto;
+import com.market.openmarket.domain.user.entity.User;
 import com.market.openmarket.domain.user.util.email.EmailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,12 +20,36 @@ public class UserServiceImpl implements UserService {
 
     private final EmailService emailService;
 
-    @Transactional
+    @Transactional(readOnly = true)
     public User findByIdOrFail(Long id) {
         return userRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
     }
 
     @Transactional
+    public User createUser(UserSignUpRequestDto requestDto) {
+        userValidator.validateDuplicate(requestDto);
+
+        User user = User.builder()
+                .email(requestDto.getEmail())
+                .pwd(requestDto.getPwd())
+                .name(requestDto.getName())
+                .phone(requestDto.getPhone())
+                .nickname(requestDto.getNickname())
+                .address(requestDto.getAddress())
+                .isDeleted(false)
+                .type(requestDto.getType())
+                .build();
+
+        return userRepository.save(user);
+    }
+
+    @Transactional(readOnly = true)
+    public User findByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+    }
+
+    @Transactional(readOnly = true)
     public UserResponseDto getUser(Long id) {
         User user = findByIdOrFail(id);
 

--- a/src/main/java/com/market/openmarket/domain/user/UserServiceImpl.java
+++ b/src/main/java/com/market/openmarket/domain/user/UserServiceImpl.java
@@ -44,7 +44,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Transactional(readOnly = true)
-    public User findByEmail(String email) {
+    public User findByEmailOrFail(String email) {
         return userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
     }
@@ -86,11 +86,8 @@ public class UserServiceImpl implements UserService {
         // TODO: Postgres 의 경우, partial unique index 를 사용하여 해결 가능함.
     }
 
-    @Transactional
     public void sendPasswordResetEmail(String email) {
-        userRepository.existsByEmail(email);
-
-        // TODO: 운영환경 주소 변경
+        userValidator.checkEmailExists(email);
         emailService.sendPasswordResetEmail(email);
     }
 }

--- a/src/test/java/com/market/openmarket/auth/AuthServiceTest.java
+++ b/src/test/java/com/market/openmarket/auth/AuthServiceTest.java
@@ -1,20 +1,19 @@
 package com.market.openmarket.auth;
 
 import com.market.openmarket.common.config.TokenProperties;
+import com.market.openmarket.common.dto.UserResponseDto;
+import com.market.openmarket.common.exception.DuplicateUserException;
 import com.market.openmarket.domain.auth.AuthServiceImpl;
 import com.market.openmarket.domain.auth.JwtToken;
 import com.market.openmarket.domain.auth.RefreshTokenRepository;
 import com.market.openmarket.domain.auth.dto.UserLogInRequestDto;
-import com.market.openmarket.domain.auth.dto.UserSignUpRequestDto;
 import com.market.openmarket.domain.auth.dto.UserLogInResponseDto;
-import com.market.openmarket.common.dto.UserResponseDto;
-import com.market.openmarket.domain.user.entity.User;
-import com.market.openmarket.domain.user.entity.UserType;
-import com.market.openmarket.common.exception.DuplicateUserException;
-import com.market.openmarket.domain.user.UserRepository;
-import com.market.openmarket.common.util.UserValidator;
+import com.market.openmarket.domain.auth.dto.UserSignUpRequestDto;
 import com.market.openmarket.domain.auth.util.bcrypt.PasswordEncoder;
 import com.market.openmarket.domain.auth.util.jwt.JwtProvider;
+import com.market.openmarket.domain.user.UserService;
+import com.market.openmarket.domain.user.entity.User;
+import com.market.openmarket.domain.user.entity.UserType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,29 +25,25 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Date;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
 
     @Mock
-    private UserRepository userRepository;
-
-    @Mock
     private PasswordEncoder passwordEncoder;
-
-    @Mock
-    private UserValidator userValidator;
 
     @Mock
     private JwtProvider jwtProvider;
 
     @Mock
     private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private UserService userService;
 
     @InjectMocks
     private AuthServiceImpl authService;
@@ -92,46 +87,34 @@ class AuthServiceTest {
     void signUp() {
         String hashedPwd = "hashedPassword123";
         when(passwordEncoder.hash(signUpRequestDto.getPwd())).thenReturn(hashedPwd);
-        User savedUser = User.builder()
-                .id(1L)
-                .email(signUpRequestDto.getEmail())
-                .pwd(hashedPwd)
-                .name(signUpRequestDto.getName())
-                .phone(signUpRequestDto.getPhone())
-                .nickname(signUpRequestDto.getNickname())
-                .address(signUpRequestDto.getAddress())
-                .isDeleted(false)
-                .type(signUpRequestDto.getType())
-                .build();
-        when(userRepository.save(any(User.class))).thenReturn(savedUser);
+        when(userService.createUser(any(UserSignUpRequestDto.class))).thenReturn(fakeUser);
 
         UserResponseDto responseDto = authService.signUp(signUpRequestDto);
 
-        assertEquals(1L, responseDto.getId());
-        assertEquals(signUpRequestDto.getEmail(), responseDto.getEmail());
-        assertEquals(signUpRequestDto.getName(), responseDto.getName());
-        assertEquals(signUpRequestDto.getPhone(), responseDto.getPhone());
-        assertEquals(signUpRequestDto.getNickname(), responseDto.getNickname());
-        assertEquals(signUpRequestDto.getAddress(), responseDto.getAddress());
-        assertEquals(signUpRequestDto.getType(), responseDto.getType());
+        assertThat(responseDto.getId()).isEqualTo(fakeUser.getId());
+        assertThat(responseDto.getEmail()).isEqualTo(fakeUser.getEmail());
+        assertThat(responseDto.getName()).isEqualTo(fakeUser.getName());
+        assertThat(responseDto.getPhone()).isEqualTo(fakeUser.getPhone());
+        assertThat(responseDto.getNickname()).isEqualTo(fakeUser.getNickname());
+        assertThat(responseDto.getAddress()).isEqualTo(fakeUser.getAddress());
+        assertThat(responseDto.getType()).isEqualTo(fakeUser.getType());
     }
 
     @Test
     @DisplayName("회원가입 실패 - 이메일 중복")
     void signUpFailed() {
-        doThrow(new DuplicateUserException("Duplicate email")).when(userValidator).validateDuplicate(signUpRequestDto);
+        when(userService.createUser(any(UserSignUpRequestDto.class)))
+                .thenThrow(new DuplicateUserException("이미 사용 중인 이메일입니다."));
 
-        assertThrows(DuplicateUserException.class, () -> {
-            authService.signUp(signUpRequestDto);
-        });
+        assertThatThrownBy(() -> authService.signUp(signUpRequestDto))
+                .isInstanceOf(DuplicateUserException.class);
     }
 
     @Test
     @DisplayName("로그인 성공")
     void logIn() {
-        when(userRepository.findByEmail(logInRequestDto.getEmail()))
-                .thenReturn(Optional.of(fakeUser));
-
+        when(userService.findByEmailOrFail(logInRequestDto.getEmail()))
+                .thenReturn(fakeUser);
         when(passwordEncoder.checkPwd(logInRequestDto.getPwd(), fakeUser.getPwd()))
                 .thenReturn(true);
 
@@ -148,8 +131,8 @@ class AuthServiceTest {
 
         UserLogInResponseDto responseDto = authService.logIn(logInRequestDto);
 
-        assertEquals("access-token", responseDto.getAccessToken());
-        assertEquals("refresh-token", responseDto.getRefreshToken());
+        assertThat("access-token").isEqualTo(responseDto.getAccessToken());
+        assertThat("refresh-token").isEqualTo(responseDto.getRefreshToken());
     }
 
     @Test
@@ -157,11 +140,10 @@ class AuthServiceTest {
     void LogInFailedByNoUser() {
         logInRequestDto.setEmail("wrong@wrong.com");
 
-        when(userRepository.findByEmail(logInRequestDto.getEmail())).thenReturn(Optional.empty());
+        when(userService.findByEmailOrFail(logInRequestDto.getEmail())).thenThrow(new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
-        assertThrows(IllegalArgumentException.class, () -> {
-            authService.logIn(logInRequestDto);
-        });
+        assertThatThrownBy(() -> authService.logIn(logInRequestDto))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -169,11 +151,10 @@ class AuthServiceTest {
     void logInFailedByPwd() {
         logInRequestDto.setPwd("wrong");
 
-        when(userRepository.findByEmail(logInRequestDto.getEmail())).thenReturn(Optional.of(fakeUser));
+        when(userService.findByEmailOrFail(logInRequestDto.getEmail())).thenReturn(fakeUser);
         when(passwordEncoder.checkPwd(logInRequestDto.getPwd(), fakeUser.getPwd())).thenReturn(false);
 
-        assertThrows(IllegalArgumentException.class, () -> {
-            authService.logIn(logInRequestDto);
-        });
+        assertThatThrownBy(() -> authService.logIn(logInRequestDto))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/com/market/openmarket/user/UserServiceTest.java
+++ b/src/test/java/com/market/openmarket/user/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.market.openmarket.user;
 
+import com.market.openmarket.domain.auth.dto.UserSignUpRequestDto;
 import com.market.openmarket.domain.user.UserRepository;
 import com.market.openmarket.domain.user.UserServiceImpl;
 import com.market.openmarket.domain.user.dto.UserUpdateRequestDto;
@@ -18,6 +19,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -34,6 +37,7 @@ class UserServiceTest {
     private UserServiceImpl userService;
 
     private User fakeUser;
+    private UserSignUpRequestDto signUpRequestDto;
 
     @BeforeEach
     void setUp() {
@@ -48,30 +52,102 @@ class UserServiceTest {
                 .isDeleted(false)
                 .type(UserType.CUSTOMER)
                 .build();
+
+        signUpRequestDto = UserSignUpRequestDto.builder()
+                .email("test@test.com")
+                .pwd("1234")
+                .build();
     }
 
     @Test
-    @DisplayName("유저를 id로 찾는다.")
+    @DisplayName("유저를 id 로 조회한다.")
+    void findByIdOrFail() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(fakeUser));
+
+        User user = userService.findByIdOrFail(1L);
+
+        assertThat(user.getId()).isEqualTo(fakeUser.getId());
+        assertThat(user.getEmail()).isEqualTo(fakeUser.getEmail());
+        assertThat(user.getName()).isEqualTo(fakeUser.getName());
+        assertThat(user.getPhone()).isEqualTo(fakeUser.getPhone());
+        assertThat(user.getNickname()).isEqualTo(fakeUser.getNickname());
+        assertThat(user.getAddress()).isEqualTo(fakeUser.getAddress());
+    }
+
+    @Test
+    @DisplayName("유저를 id 로 조회하기에 실패한다.")
+    void findByIdOrFailFailed() {
+        when(userRepository.findById(1L)).thenThrow(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> userService.findByIdOrFail(1L))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("유저를 이메일로 조회한다.")
+    void findByEmailOrFail() {
+        when(userRepository.findByEmail("test@test.com")).thenReturn(Optional.of(fakeUser));
+        User user = userService.findByEmailOrFail("test@test.com");
+
+        assertThat(user.getId()).isEqualTo(fakeUser.getId());
+    }
+
+    @Test
+    @DisplayName("유저를 이메일로 조회하기에 실패한다.")
+    void findByEmailOrFailFailed() {
+        when(userRepository.findByEmail("wrong@test.com")).thenThrow(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> userService.findByEmailOrFail("wrong@test.com"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("유저 정보를 가져온다.")
     void getUser() {
         when(userRepository.findById(1L)).thenReturn(Optional.of(fakeUser));
         UserResponseDto responseDto = userService.getUser(1L);
 
-        assertEquals(fakeUser.getId(), responseDto.getId());
-        assertEquals(fakeUser.getEmail(), responseDto.getEmail());
-        assertEquals(fakeUser.getName(), responseDto.getName());
-        assertEquals(fakeUser.getPhone(), responseDto.getPhone());
-        assertEquals(fakeUser.getNickname(), responseDto.getNickname());
-        assertEquals(fakeUser.getAddress(), responseDto.getAddress());
+        assertThat(fakeUser.getId()).isEqualTo(responseDto.getId());
+        assertThat(fakeUser.getEmail()).isEqualTo(responseDto.getEmail());
+        assertThat(fakeUser.getName()).isEqualTo(responseDto.getName());
+        assertThat(fakeUser.getPhone()).isEqualTo(responseDto.getPhone());
+        assertThat(fakeUser.getNickname()).isEqualTo(responseDto.getNickname());
+        assertThat(fakeUser.getAddress()).isEqualTo(responseDto.getAddress());
     }
 
     @Test
-    @DisplayName("유저를 id로 찾는데 실패한다.")
+    @DisplayName("유저 정보를 가져오기에 실패한다.")
     void getUserFailed() {
         when(userRepository.findById(1L)).thenThrow(IllegalArgumentException.class);
 
-        assertThrows(IllegalArgumentException.class, () -> {
-            userService.getUser(1L);
-        });
+        assertThatThrownBy(() -> userService.getUser(1L))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("회원 생성에 성공한다.")
+    void createUser() {
+        doNothing().when(userValidator).validateDuplicate(signUpRequestDto);
+        when(userRepository.save(any(User.class))).thenReturn(fakeUser);
+
+        User user = userService.createUser(signUpRequestDto);
+
+        assertThat(user.getId()).isEqualTo(fakeUser.getId());
+        assertThat(user.getEmail()).isEqualTo(fakeUser.getEmail());
+        assertThat(user.getName()).isEqualTo(fakeUser.getName());
+        assertThat(user.getPhone()).isEqualTo(fakeUser.getPhone());
+        assertThat(user.getNickname()).isEqualTo(fakeUser.getNickname());
+        assertThat(user.getAddress()).isEqualTo(fakeUser.getAddress());
+        assertThat(user.getType()).isEqualTo(fakeUser.getType());
+    }
+
+    @Test
+    @DisplayName("회원 생성에 실패 - 중복된 정보")
+    void createUserFailedByDuplicatedEmail() {
+        doThrow(DuplicateUserException.class).when(userValidator).validateDuplicate(signUpRequestDto);
+
+        assertThatThrownBy(() -> userService.createUser(signUpRequestDto))
+                .isInstanceOf(DuplicateUserException.class);
     }
 
     @Test
@@ -87,9 +163,9 @@ class UserServiceTest {
 
         UserResponseDto responseDto = userService.updateUser(1L, requestDto);
 
-        assertEquals("koko", responseDto.getNickname());
-        assertEquals("010-2345-3456", responseDto.getPhone());
-        assertEquals("changed-address", responseDto.getAddress());
+        assertThat(responseDto.getNickname()).isEqualTo("koko");
+        assertThat(responseDto.getPhone()).isEqualTo("010-2345-3456");
+        assertThat(responseDto.getAddress()).isEqualTo("changed-address");
     }
 
     @Test
@@ -102,8 +178,8 @@ class UserServiceTest {
         when(userRepository.findById(1L)).thenReturn(Optional.of(fakeUser));
         doThrow(DuplicateUserException.class).when(userValidator).validateDuplicateForUpdate(1L, updateDto);
 
-        assertThrows(DuplicateUserException.class, () ->
-                userService.updateUser(1L, updateDto));
+        assertThatThrownBy(() -> userService.updateUser(1L, updateDto))
+                .isInstanceOf(DuplicateUserException.class);
     }
 
     @Test
@@ -116,8 +192,8 @@ class UserServiceTest {
         when(userRepository.findById(1L)).thenReturn(Optional.of(fakeUser));
         doThrow(DuplicateUserException.class).when(userValidator).validateDuplicateForUpdate(1L, updateDto);
 
-        assertThrows(DuplicateUserException.class, () ->
-                userService.updateUser(1L, updateDto));
+        assertThatThrownBy(() -> userService.updateUser(1L, updateDto))
+                .isInstanceOf(DuplicateUserException.class);
     }
 
     @Test
@@ -137,8 +213,7 @@ class UserServiceTest {
     void deleteUserFailed() {
         when(userRepository.findById(1L)).thenThrow(IllegalArgumentException.class);
 
-        assertThrows(IllegalArgumentException.class, () -> {
-            userService.deleteUser(1L);
-        });
+        assertThatThrownBy(() -> userService.deleteUser(1L))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }


### PR DESCRIPTION
1. 회원가입과 로그인 시 AuthService에서 직접적으로 UserRepository를 의존하고 있던 동작을 UserService에 위임하였습니다.
2. 데이터베이스 조회 로직에는 더티체킹이 적용되지 않고 데이터 변경이 없는 작업임을 명시적으로 알 수 있도록 @Transactional(readonly = true) 어노테이션을 사용하였습니다.
3. UserServiceImpl.findByXXorFail() 메서드는 내부 호출만 적용되지만 추후 다른 도메인에서의 호출 가능성을 염두에 두고 읽기전용 트랜잭션을 적용했습니다. 디폴트 REQUIRED 옵션으로 상위 트랜잭션에 참여하도록 하였습니다.
4.  유저서비스의 이메일 발송 로직에서 단순 존재 조회임에도 긴 트랜잭션을 가져가는 이슈가 있었습니다. 이 부분을 Validator에게 위임하여 빠른 커넥션 반납을 할 수 있게끔 만들었습니다.