### PR TITLE
Feat/18 password

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/src/main/java/com/market/openmarket/common/config/TokenProperties.java
+++ b/src/main/java/com/market/openmarket/common/config/TokenProperties.java
@@ -5,4 +5,6 @@ public class TokenProperties {
     public static final int ACCESS_TOKEN_EXPIRATION_MINUTES = 15;
 
     public static final int REFRESH_TOKEN_EXPIRATION_DAYS = 15;
+
+    public static final int PASSWORD_RESET_EXPIRATION_MINUTES = 10;
 }

--- a/src/main/java/com/market/openmarket/common/util/UserValidator.java
+++ b/src/main/java/com/market/openmarket/common/util/UserValidator.java
@@ -6,6 +6,7 @@ import com.market.openmarket.common.exception.DuplicateUserException;
 import com.market.openmarket.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -13,6 +14,7 @@ public class UserValidator {
 
     private final UserRepository userRepository;
 
+    @Transactional(readOnly = true)
     public void validateDuplicate(UserSignUpRequestDto requestDto) {
         if (userRepository.existsByEmail(requestDto.getEmail())) {
             throw new DuplicateUserException("이미 사용 중인 이메일입니다.");
@@ -25,6 +27,7 @@ public class UserValidator {
         }
     }
 
+    @Transactional(readOnly = true)
     public void validateDuplicateForUpdate(Long userId, UserUpdateRequestDto requestDto) {
         if (requestDto.getNickname() != null) {
             userRepository.findByNickname(requestDto.getNickname())
@@ -39,6 +42,14 @@ public class UserValidator {
                     .ifPresent(user -> {
                         throw new DuplicateUserException("이미 사용 중인 전화번호입니다.");
                     });
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public void checkEmailExists(String email) {
+        boolean isExist = userRepository.existsByEmail(email);
+        if (!isExist) {
+            throw new IllegalArgumentException("존재하지 않는 이메일입니다.");
         }
     }
 }

--- a/src/main/java/com/market/openmarket/domain/auth/AuthController.java
+++ b/src/main/java/com/market/openmarket/domain/auth/AuthController.java
@@ -1,19 +1,18 @@
 package com.market.openmarket.domain.auth;
 
 import com.market.openmarket.common.config.TokenProperties;
-import com.market.openmarket.domain.auth.dto.UserLogInRequestDto;
-import com.market.openmarket.domain.auth.dto.UserSignUpRequestDto;
-import com.market.openmarket.domain.auth.dto.UserLogInResponseDto;
 import com.market.openmarket.common.dto.UserResponseDto;
+import com.market.openmarket.domain.auth.dto.UserLogInRequestDto;
+import com.market.openmarket.domain.auth.dto.UserLogInResponseDto;
+import com.market.openmarket.domain.auth.dto.UserSignUpRequestDto;
+import com.market.openmarket.domain.user.dto.PasswordFindRequestDto;
+import com.market.openmarket.domain.user.dto.PasswordResetRequestDto;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -43,5 +42,22 @@ public class AuthController {
         res.addCookie(cookie);
 
         return ResponseEntity.ok(tokens.getAccessToken());
+    }
+
+
+    @PostMapping("/password-reset/request")
+    public ResponseEntity<String> sendPasswordResetEmail(@RequestBody PasswordFindRequestDto requestDto) {
+        authService.sendPasswordResetEmail(requestDto.getEmail());
+        return ResponseEntity.ok("비밀번호 재설정 이메일을 발송했습니다.");
+    }
+
+    @PostMapping("/password-reset/confirm")
+    public ResponseEntity<String> resetPassword(
+            @RequestParam("email") String email,
+            @RequestParam("token") String token,
+            @RequestBody PasswordResetRequestDto requestDto
+    ) {
+        authService.resetPassword(email, token, requestDto);
+        return ResponseEntity.ok("비밀번호가 재설정되었습니다.");
     }
 }

--- a/src/main/java/com/market/openmarket/domain/auth/AuthService.java
+++ b/src/main/java/com/market/openmarket/domain/auth/AuthService.java
@@ -1,13 +1,18 @@
 package com.market.openmarket.domain.auth;
 
-import com.market.openmarket.domain.auth.dto.UserLogInRequestDto;
-import com.market.openmarket.domain.auth.dto.UserSignUpRequestDto;
-import com.market.openmarket.domain.auth.dto.UserLogInResponseDto;
 import com.market.openmarket.common.dto.UserResponseDto;
+import com.market.openmarket.domain.auth.dto.UserLogInRequestDto;
+import com.market.openmarket.domain.auth.dto.UserLogInResponseDto;
+import com.market.openmarket.domain.auth.dto.UserSignUpRequestDto;
+import com.market.openmarket.domain.user.dto.PasswordResetRequestDto;
 
 public interface AuthService {
 
     UserResponseDto signUp(UserSignUpRequestDto requestDto);
 
     UserLogInResponseDto logIn(UserLogInRequestDto requestDto);
+
+    void sendPasswordResetEmail(String email);
+
+    void resetPassword(String email, String token, PasswordResetRequestDto requestDto);
 }

--- a/src/main/java/com/market/openmarket/domain/auth/AuthServiceImpl.java
+++ b/src/main/java/com/market/openmarket/domain/auth/AuthServiceImpl.java
@@ -1,14 +1,18 @@
 package com.market.openmarket.domain.auth;
 
 import com.market.openmarket.common.dto.UserResponseDto;
+import com.market.openmarket.common.util.UserValidator;
 import com.market.openmarket.domain.auth.dto.UserLogInRequestDto;
 import com.market.openmarket.domain.auth.dto.UserLogInResponseDto;
 import com.market.openmarket.domain.auth.dto.UserSignUpRequestDto;
 import com.market.openmarket.domain.auth.entity.RefreshToken;
 import com.market.openmarket.domain.auth.util.bcrypt.PasswordEncoder;
 import com.market.openmarket.domain.auth.util.jwt.JwtProvider;
+import com.market.openmarket.domain.auth.util.jwt.TokenService;
 import com.market.openmarket.domain.user.UserService;
+import com.market.openmarket.domain.user.dto.PasswordResetRequestDto;
 import com.market.openmarket.domain.user.entity.User;
+import com.market.openmarket.domain.user.util.email.EmailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +28,9 @@ public class AuthServiceImpl implements AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final UserValidator userValidator;
+    private final EmailService emailService;
+    private final TokenService tokenService;
 
     @Transactional
     public UserResponseDto signUp(UserSignUpRequestDto requestDto) {
@@ -64,5 +71,25 @@ public class AuthServiceImpl implements AuthService {
                 .accessToken(accessToken.getToken())
                 .refreshToken(refreshToken.getToken())
                 .build();
+    }
+
+    public void sendPasswordResetEmail(String email) {
+        userValidator.checkEmailExists(email);
+
+        String token = tokenService.savePasswordResetToken(email);
+        emailService.sendPasswordResetEmail(email, token);
+    }
+
+    public void resetPassword(String email, String token, PasswordResetRequestDto requestDto) {
+        userValidator.checkEmailExists(email);
+        if (!requestDto.getNewPwd().equals(requestDto.getConfirmPwd())) {
+            throw new IllegalArgumentException("비밀번호를 다시 입력해주세요.");
+        }
+
+        tokenService.validatePasswordResetToken(email, token);
+
+        String hashedPwd = passwordEncoder.hash(requestDto.getNewPwd());
+        userService.updatePassword(email, hashedPwd);
+        tokenService.deletePasswordResetToken(email);
     }
 }

--- a/src/main/java/com/market/openmarket/domain/auth/AuthServiceImpl.java
+++ b/src/main/java/com/market/openmarket/domain/auth/AuthServiceImpl.java
@@ -34,6 +34,10 @@ public class AuthServiceImpl implements AuthService {
 
     @Transactional
     public UserResponseDto signUp(UserSignUpRequestDto requestDto) {
+        if (!requestDto.getPwd().equals(requestDto.getConfirmPwd())) {
+            throw new IllegalArgumentException("비밀번호를 다시 입력해주세요.");
+        }
+
         String hashedPwd = passwordEncoder.hash(requestDto.getPwd());
         requestDto.setPwd(hashedPwd);
 

--- a/src/main/java/com/market/openmarket/domain/auth/AuthServiceImpl.java
+++ b/src/main/java/com/market/openmarket/domain/auth/AuthServiceImpl.java
@@ -1,15 +1,14 @@
 package com.market.openmarket.domain.auth;
 
-import com.market.openmarket.domain.auth.entity.RefreshToken;
-import com.market.openmarket.domain.auth.dto.UserLogInRequestDto;
-import com.market.openmarket.domain.auth.dto.UserSignUpRequestDto;
-import com.market.openmarket.domain.auth.dto.UserLogInResponseDto;
 import com.market.openmarket.common.dto.UserResponseDto;
-import com.market.openmarket.domain.user.entity.User;
-import com.market.openmarket.domain.user.UserRepository;
-import com.market.openmarket.common.util.UserValidator;
+import com.market.openmarket.domain.auth.dto.UserLogInRequestDto;
+import com.market.openmarket.domain.auth.dto.UserLogInResponseDto;
+import com.market.openmarket.domain.auth.dto.UserSignUpRequestDto;
+import com.market.openmarket.domain.auth.entity.RefreshToken;
 import com.market.openmarket.domain.auth.util.bcrypt.PasswordEncoder;
 import com.market.openmarket.domain.auth.util.jwt.JwtProvider;
+import com.market.openmarket.domain.user.UserService;
+import com.market.openmarket.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,37 +20,23 @@ import java.time.ZoneId;
 @RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
 
-    private final UserRepository userRepository;
+    private final UserService userService;
     private final PasswordEncoder passwordEncoder;
-    private final UserValidator userValidator;
     private final JwtProvider jwtProvider;
     private final RefreshTokenRepository refreshTokenRepository;
 
     @Transactional
     public UserResponseDto signUp(UserSignUpRequestDto requestDto) {
-        userValidator.validateDuplicate(requestDto);
         String hashedPwd = passwordEncoder.hash(requestDto.getPwd());
+        requestDto.setPwd(hashedPwd);
 
-        User user = User.builder()
-                .email(requestDto.getEmail())
-                .pwd(hashedPwd)
-                .name(requestDto.getName())
-                .phone(requestDto.getPhone())
-                .nickname(requestDto.getNickname())
-                .address(requestDto.getAddress())
-                .isDeleted(false)
-                .type(requestDto.getType())
-                .build();
-
-        User savedUser = userRepository.save(user);
-
+        User savedUser = userService.createUser(requestDto);
         return UserResponseDto.fromEntity(savedUser);
     }
 
     @Transactional
     public UserLogInResponseDto logIn(UserLogInRequestDto requestDto) {
-        User user = userRepository.findByEmail(requestDto.getEmail())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        User user = userService.findByEmail(requestDto.getEmail());
 
         boolean isValid = passwordEncoder.checkPwd(requestDto.getPwd(), user.getPwd());
         if (!isValid) {
@@ -61,7 +46,6 @@ public class AuthServiceImpl implements AuthService {
         JwtToken accessToken = jwtProvider.generateAccessToken(user);
         JwtToken refreshToken = jwtProvider.generateRefreshToken(user);
 
-        // TODO: 리팩터링 시 JPA AttributeConverter 적용하기
         LocalDateTime issuedAt = LocalDateTime.ofInstant(refreshToken.getIssuedAt().toInstant(), ZoneId.of("UTC"));
         LocalDateTime expiresAt = LocalDateTime.ofInstant(refreshToken.getExpiration().toInstant(), ZoneId.of("UTC"));
 
@@ -70,12 +54,10 @@ public class AuthServiceImpl implements AuthService {
                         .userId(user.getId()).build()
                 );
 
-        // 토큰을 가진 유저가 새로 로그인한다면 토큰 값과 발행일자, 만료일자 새로 세팅
         refreshTokenEntity.setToken(refreshToken.getToken());
         refreshTokenEntity.setIssuedAt(issuedAt);
         refreshTokenEntity.setExpiresAt(expiresAt);
 
-        // 신규 엔티티의 경우 JPA DirtyChecking 적용 안됨. 명시적 save() 호출
         refreshTokenRepository.save(refreshTokenEntity);
 
         return UserLogInResponseDto.builder()

--- a/src/main/java/com/market/openmarket/domain/auth/AuthServiceImpl.java
+++ b/src/main/java/com/market/openmarket/domain/auth/AuthServiceImpl.java
@@ -36,7 +36,7 @@ public class AuthServiceImpl implements AuthService {
 
     @Transactional
     public UserLogInResponseDto logIn(UserLogInRequestDto requestDto) {
-        User user = userService.findByEmail(requestDto.getEmail());
+        User user = userService.findByEmailOrFail(requestDto.getEmail());
 
         boolean isValid = passwordEncoder.checkPwd(requestDto.getPwd(), user.getPwd());
         if (!isValid) {

--- a/src/main/java/com/market/openmarket/domain/auth/dto/UserSignUpRequestDto.java
+++ b/src/main/java/com/market/openmarket/domain/auth/dto/UserSignUpRequestDto.java
@@ -20,6 +20,9 @@ public class UserSignUpRequestDto {
     @NotBlank(message = "Password is required.")
     private String pwd;
 
+    @NotBlank(message = "Password confirmation is required.")
+    private String confirmPwd;
+
     @NotBlank(message = "Name is required.")
     private String name;
 

--- a/src/main/java/com/market/openmarket/domain/auth/util/jwt/JwtProvider.java
+++ b/src/main/java/com/market/openmarket/domain/auth/util/jwt/JwtProvider.java
@@ -9,9 +9,9 @@ public interface JwtProvider {
 
     JwtToken generateRefreshToken(User user);
 
-    JwtToken generatePasswordResetToken(String email);
+    String generatePasswordResetToken(String email);
 
     boolean validateToken(String token);
 
-    String getEmailFromToken(String token);
+    String getSubjectFromToken(String token);
 }

--- a/src/main/java/com/market/openmarket/domain/auth/util/jwt/JwtProvider.java
+++ b/src/main/java/com/market/openmarket/domain/auth/util/jwt/JwtProvider.java
@@ -8,4 +8,10 @@ public interface JwtProvider {
     JwtToken generateAccessToken(User user);
 
     JwtToken generateRefreshToken(User user);
+
+    JwtToken generatePasswordResetToken(String email);
+
+    boolean validateToken(String token);
+
+    String getEmailFromToken(String token);
 }

--- a/src/main/java/com/market/openmarket/domain/auth/util/jwt/JwtProviderImpl.java
+++ b/src/main/java/com/market/openmarket/domain/auth/util/jwt/JwtProviderImpl.java
@@ -3,22 +3,25 @@ package com.market.openmarket.domain.auth.util.jwt;
 import com.market.openmarket.domain.auth.JwtToken;
 import com.market.openmarket.common.config.TokenProperties;
 import com.market.openmarket.domain.user.entity.User;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
-import java.security.Key;
 import java.util.Date;
 
+@Slf4j
 @Component
 public class JwtProviderImpl implements JwtProvider {
 
     @Value("${jwt.secret}")
     private String rawKey;
 
-    private Key generateKey() {
+    private SecretKey generateKey() {
         byte[] keyByte = rawKey.getBytes(StandardCharsets.UTF_8);
 
         return Keys.hmacShaKeyFor(keyByte);
@@ -54,5 +57,49 @@ public class JwtProviderImpl implements JwtProvider {
                 .compact();
 
         return new JwtToken(token, now, expiresDate);
+    }
+
+    public JwtToken generatePasswordResetToken(String email) {
+        Date now = new Date();
+        long passwordResetTokenExpiration = 1000L * 60 * TokenProperties.PASSWORD_RESET_EXPIRATION_MINUTES;
+        Date expiresDate = new Date(now.getTime() + passwordResetTokenExpiration);
+
+        String token = Jwts.builder()
+                .subject(email)
+                .issuedAt(now)
+                .expiration(expiresDate)
+                .claim("purpose", "password-reset")
+                .signWith(generateKey())
+                .compact();
+
+        return new JwtToken(token, now, expiresDate);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(generateKey())
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (Exception e) {
+            log.warn("JWT 검증 실패: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    public String getEmailFromToken(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(generateKey())
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+
+            return claims.getSubject();
+        } catch (Exception e) {
+            log.warn("토큰에서 이메일 추출 실패: {}", e.getMessage());
+            return null;
+        }
     }
 }

--- a/src/main/java/com/market/openmarket/domain/auth/util/jwt/JwtProviderImpl.java
+++ b/src/main/java/com/market/openmarket/domain/auth/util/jwt/JwtProviderImpl.java
@@ -1,7 +1,7 @@
 package com.market.openmarket.domain.auth.util.jwt;
 
-import com.market.openmarket.domain.auth.JwtToken;
 import com.market.openmarket.common.config.TokenProperties;
+import com.market.openmarket.domain.auth.JwtToken;
 import com.market.openmarket.domain.user.entity.User;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -59,20 +59,18 @@ public class JwtProviderImpl implements JwtProvider {
         return new JwtToken(token, now, expiresDate);
     }
 
-    public JwtToken generatePasswordResetToken(String email) {
+    public String generatePasswordResetToken(String email) {
         Date now = new Date();
         long passwordResetTokenExpiration = 1000L * 60 * TokenProperties.PASSWORD_RESET_EXPIRATION_MINUTES;
         Date expiresDate = new Date(now.getTime() + passwordResetTokenExpiration);
 
-        String token = Jwts.builder()
+        return Jwts.builder()
                 .subject(email)
                 .issuedAt(now)
                 .expiration(expiresDate)
                 .claim("purpose", "password-reset")
                 .signWith(generateKey())
                 .compact();
-
-        return new JwtToken(token, now, expiresDate);
     }
 
     public boolean validateToken(String token) {
@@ -88,7 +86,7 @@ public class JwtProviderImpl implements JwtProvider {
         }
     }
 
-    public String getEmailFromToken(String token) {
+    public String getSubjectFromToken(String token) {
         try {
             Claims claims = Jwts.parser()
                     .verifyWith(generateKey())
@@ -98,7 +96,7 @@ public class JwtProviderImpl implements JwtProvider {
 
             return claims.getSubject();
         } catch (Exception e) {
-            log.warn("토큰에서 이메일 추출 실패: {}", e.getMessage());
+            log.warn("토큰에서 subject 추출 실패: {}", e.getMessage());
             return null;
         }
     }

--- a/src/main/java/com/market/openmarket/domain/auth/util/jwt/TokenService.java
+++ b/src/main/java/com/market/openmarket/domain/auth/util/jwt/TokenService.java
@@ -1,8 +1,6 @@
-package com.market.openmarket.domain.user.util.token;
+package com.market.openmarket.domain.auth.util.jwt;
 
 import com.market.openmarket.common.config.TokenProperties;
-import com.market.openmarket.domain.auth.JwtToken;
-import com.market.openmarket.domain.auth.util.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -13,15 +11,13 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class PasswordResetTokenService {
+public class TokenService {
 
     private final JwtProvider jwtProvider;
     private final RedisTemplate<String, String> redisTemplate;
 
-    public String generatePasswordResetToken(String email) {
-        JwtToken passwordResetToken = jwtProvider.generatePasswordResetToken(email);
-        String token = passwordResetToken.getToken();
-
+    public String savePasswordResetToken(String email) {
+        String token = jwtProvider.generatePasswordResetToken(email);
         redisTemplate.opsForValue().set(
                 email,
                 token,
@@ -32,27 +28,28 @@ public class PasswordResetTokenService {
         return token;
     }
 
-    public boolean validateToken(String email, String token) {
+    public void validatePasswordResetToken(String email, String token) {
         String storedToken = redisTemplate.opsForValue().get(email);
         if (storedToken == null || !storedToken.equals(token)) {
-            return false;
+            throw new IllegalArgumentException("유효하지 않은 비밀번호 재설정 토큰입니다.");
         }
 
         try {
             boolean isValid = jwtProvider.validateToken(token);
             if (!isValid) {
-                return false;
+                throw new IllegalArgumentException("비밀번호 재설정 토큰이 만료되었습니다.");
             }
 
-            String tokenEmail = jwtProvider.getEmailFromToken(token);
-            return email.equals(tokenEmail);
+            String tokenEmail = jwtProvider.getSubjectFromToken(token);
+            if (!tokenEmail.equals(email)) {
+                throw new IllegalArgumentException("토큰과 이메일이 일치하지 않습니다.");
+            }
         } catch (Exception e) {
             log.warn("토큰 검증 실패: {}", e.getMessage());
-            return false;
         }
     }
 
-    public void deleteToken(String email) {
+    public void deletePasswordResetToken(String email) {
         redisTemplate.delete(email);
     }
 }

--- a/src/main/java/com/market/openmarket/domain/auth/util/jwt/TokenService.java
+++ b/src/main/java/com/market/openmarket/domain/auth/util/jwt/TokenService.java
@@ -1,55 +1,10 @@
 package com.market.openmarket.domain.auth.util.jwt;
 
-import com.market.openmarket.common.config.TokenProperties;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.stereotype.Service;
+public interface TokenService {
 
-import java.util.concurrent.TimeUnit;
+    String savePasswordResetToken(String email);
 
-@Slf4j
-@Service
-@RequiredArgsConstructor
-public class TokenService {
+    void validatePasswordResetToken(String email, String token);
 
-    private final JwtProvider jwtProvider;
-    private final RedisTemplate<String, String> redisTemplate;
-
-    public String savePasswordResetToken(String email) {
-        String token = jwtProvider.generatePasswordResetToken(email);
-        redisTemplate.opsForValue().set(
-                email,
-                token,
-                TokenProperties.PASSWORD_RESET_EXPIRATION_MINUTES,
-                TimeUnit.MINUTES
-        );
-
-        return token;
-    }
-
-    public void validatePasswordResetToken(String email, String token) {
-        String storedToken = redisTemplate.opsForValue().get(email);
-        if (storedToken == null || !storedToken.equals(token)) {
-            throw new IllegalArgumentException("유효하지 않은 비밀번호 재설정 토큰입니다.");
-        }
-
-        try {
-            boolean isValid = jwtProvider.validateToken(token);
-            if (!isValid) {
-                throw new IllegalArgumentException("비밀번호 재설정 토큰이 만료되었습니다.");
-            }
-
-            String tokenEmail = jwtProvider.getSubjectFromToken(token);
-            if (!tokenEmail.equals(email)) {
-                throw new IllegalArgumentException("토큰과 이메일이 일치하지 않습니다.");
-            }
-        } catch (Exception e) {
-            log.warn("토큰 검증 실패: {}", e.getMessage());
-        }
-    }
-
-    public void deletePasswordResetToken(String email) {
-        redisTemplate.delete(email);
-    }
+    void deletePasswordResetToken(String email);
 }

--- a/src/main/java/com/market/openmarket/domain/auth/util/jwt/TokenServiceImpl.java
+++ b/src/main/java/com/market/openmarket/domain/auth/util/jwt/TokenServiceImpl.java
@@ -1,0 +1,55 @@
+package com.market.openmarket.domain.auth.util.jwt;
+
+import com.market.openmarket.common.config.TokenProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenServiceImpl implements TokenService {
+
+    private final JwtProvider jwtProvider;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public String savePasswordResetToken(String email) {
+        String token = jwtProvider.generatePasswordResetToken(email);
+        redisTemplate.opsForValue().set(
+                email,
+                token,
+                TokenProperties.PASSWORD_RESET_EXPIRATION_MINUTES,
+                TimeUnit.MINUTES
+        );
+
+        return token;
+    }
+
+    public void validatePasswordResetToken(String email, String token) {
+        String storedToken = redisTemplate.opsForValue().get(email);
+        if (storedToken == null || !storedToken.equals(token)) {
+            throw new IllegalArgumentException("유효하지 않은 비밀번호 재설정 토큰입니다.");
+        }
+
+        try {
+            boolean isValid = jwtProvider.validateToken(token);
+            if (!isValid) {
+                throw new IllegalArgumentException("비밀번호 재설정 토큰이 만료되었습니다.");
+            }
+
+            String tokenEmail = jwtProvider.getSubjectFromToken(token);
+            if (!tokenEmail.equals(email)) {
+                throw new IllegalArgumentException("토큰과 이메일이 일치하지 않습니다.");
+            }
+        } catch (Exception e) {
+            log.warn("토큰 검증 실패: {}", e.getMessage());
+        }
+    }
+
+    public void deletePasswordResetToken(String email) {
+        redisTemplate.delete(email);
+    }
+}

--- a/src/main/java/com/market/openmarket/domain/user/UserController.java
+++ b/src/main/java/com/market/openmarket/domain/user/UserController.java
@@ -1,12 +1,8 @@
 package com.market.openmarket.domain.user;
 
-import com.market.openmarket.domain.user.dto.PasswordFindRequestDto;
-import com.market.openmarket.domain.user.dto.PasswordResetRequestDto;
-import com.market.openmarket.domain.user.dto.UserUpdateRequestDto;
 import com.market.openmarket.common.dto.UserResponseDto;
-import jakarta.validation.Valid;
+import com.market.openmarket.domain.user.dto.UserUpdateRequestDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -38,21 +34,5 @@ public class UserController {
         userService.deleteUser(id);
 
         return ResponseEntity.ok("success");
-    }
-
-    @PostMapping("/password-reset/request")
-    public ResponseEntity<String> sendPasswordResetEmail(@RequestBody PasswordFindRequestDto requestDto) {
-        userService.sendPasswordResetEmail(requestDto.getEmail());
-        return ResponseEntity.ok("비밀번호 재설정 이메일을 발송했습니다.");
-    }
-
-    @PostMapping("/password-reset/confirm")
-    public ResponseEntity<String> resetPassword(
-            @RequestParam("email") String email,
-            @RequestParam("token") String token,
-            @RequestBody PasswordResetRequestDto requestDto
-    ) {
-        userService.resetPassword(email, token, requestDto);
-        return ResponseEntity.ok("비밀번호가 재설정되었습니다.");
     }
 }

--- a/src/main/java/com/market/openmarket/domain/user/UserController.java
+++ b/src/main/java/com/market/openmarket/domain/user/UserController.java
@@ -1,9 +1,12 @@
 package com.market.openmarket.domain.user;
 
 import com.market.openmarket.domain.user.dto.PasswordFindRequestDto;
+import com.market.openmarket.domain.user.dto.PasswordResetRequestDto;
 import com.market.openmarket.domain.user.dto.UserUpdateRequestDto;
 import com.market.openmarket.common.dto.UserResponseDto;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -37,9 +40,19 @@ public class UserController {
         return ResponseEntity.ok("success");
     }
 
-    @PostMapping("/find-password")
-    public ResponseEntity<String> findPassword(@RequestBody PasswordFindRequestDto requestDto) {
+    @PostMapping("/password-reset/request")
+    public ResponseEntity<String> sendPasswordResetEmail(@RequestBody PasswordFindRequestDto requestDto) {
         userService.sendPasswordResetEmail(requestDto.getEmail());
         return ResponseEntity.ok("비밀번호 재설정 이메일을 발송했습니다.");
+    }
+
+    @PostMapping("/password-reset/confirm")
+    public ResponseEntity<String> resetPassword(
+            @RequestParam("email") String email,
+            @RequestParam("token") String token,
+            @RequestBody PasswordResetRequestDto requestDto
+    ) {
+        userService.resetPassword(email, token, requestDto);
+        return ResponseEntity.ok("비밀번호가 재설정되었습니다.");
     }
 }

--- a/src/main/java/com/market/openmarket/domain/user/UserService.java
+++ b/src/main/java/com/market/openmarket/domain/user/UserService.java
@@ -11,7 +11,7 @@ public interface UserService {
 
     User createUser(UserSignUpRequestDto requestDto);
 
-    User findByEmail(String email);
+    User findByEmailOrFail(String email);
 
     UserResponseDto getUser(Long id);
 

--- a/src/main/java/com/market/openmarket/domain/user/UserService.java
+++ b/src/main/java/com/market/openmarket/domain/user/UserService.java
@@ -2,6 +2,7 @@ package com.market.openmarket.domain.user;
 
 import com.market.openmarket.common.dto.UserResponseDto;
 import com.market.openmarket.domain.auth.dto.UserSignUpRequestDto;
+import com.market.openmarket.domain.user.dto.PasswordResetRequestDto;
 import com.market.openmarket.domain.user.dto.UserUpdateRequestDto;
 import com.market.openmarket.domain.user.entity.User;
 
@@ -18,6 +19,8 @@ public interface UserService {
     UserResponseDto updateUser(Long id, UserUpdateRequestDto requestDto);
 
     void sendPasswordResetEmail(String email);
+
+    void resetPassword(String email, String token, PasswordResetRequestDto requestDto);
 
     void deleteUser(Long id);
 }

--- a/src/main/java/com/market/openmarket/domain/user/UserService.java
+++ b/src/main/java/com/market/openmarket/domain/user/UserService.java
@@ -2,7 +2,6 @@ package com.market.openmarket.domain.user;
 
 import com.market.openmarket.common.dto.UserResponseDto;
 import com.market.openmarket.domain.auth.dto.UserSignUpRequestDto;
-import com.market.openmarket.domain.user.dto.PasswordResetRequestDto;
 import com.market.openmarket.domain.user.dto.UserUpdateRequestDto;
 import com.market.openmarket.domain.user.entity.User;
 
@@ -18,9 +17,7 @@ public interface UserService {
 
     UserResponseDto updateUser(Long id, UserUpdateRequestDto requestDto);
 
-    void sendPasswordResetEmail(String email);
-
-    void resetPassword(String email, String token, PasswordResetRequestDto requestDto);
+    void updatePassword(String email, String newPassword);
 
     void deleteUser(Long id);
 }

--- a/src/main/java/com/market/openmarket/domain/user/UserService.java
+++ b/src/main/java/com/market/openmarket/domain/user/UserService.java
@@ -1,12 +1,17 @@
 package com.market.openmarket.domain.user;
 
-import com.market.openmarket.domain.user.entity.User;
-import com.market.openmarket.domain.user.dto.UserUpdateRequestDto;
 import com.market.openmarket.common.dto.UserResponseDto;
+import com.market.openmarket.domain.auth.dto.UserSignUpRequestDto;
+import com.market.openmarket.domain.user.dto.UserUpdateRequestDto;
+import com.market.openmarket.domain.user.entity.User;
 
 public interface UserService {
 
     User findByIdOrFail(Long id);
+
+    User createUser(UserSignUpRequestDto requestDto);
+
+    User findByEmail(String email);
 
     UserResponseDto getUser(Long id);
 

--- a/src/main/java/com/market/openmarket/domain/user/UserServiceImpl.java
+++ b/src/main/java/com/market/openmarket/domain/user/UserServiceImpl.java
@@ -1,9 +1,10 @@
 package com.market.openmarket.domain.user;
 
-import com.market.openmarket.domain.user.entity.User;
-import com.market.openmarket.domain.user.dto.UserUpdateRequestDto;
 import com.market.openmarket.common.dto.UserResponseDto;
 import com.market.openmarket.common.util.UserValidator;
+import com.market.openmarket.domain.auth.dto.UserSignUpRequestDto;
+import com.market.openmarket.domain.user.dto.UserUpdateRequestDto;
+import com.market.openmarket.domain.user.entity.User;
 import com.market.openmarket.domain.user.util.email.EmailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,12 +20,36 @@ public class UserServiceImpl implements UserService {
 
     private final EmailService emailService;
 
-    @Transactional
+    @Transactional(readOnly = true)
     public User findByIdOrFail(Long id) {
         return userRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
     }
 
     @Transactional
+    public User createUser(UserSignUpRequestDto requestDto) {
+        userValidator.validateDuplicate(requestDto);
+
+        User user = User.builder()
+                .email(requestDto.getEmail())
+                .pwd(requestDto.getPwd())
+                .name(requestDto.getName())
+                .phone(requestDto.getPhone())
+                .nickname(requestDto.getNickname())
+                .address(requestDto.getAddress())
+                .isDeleted(false)
+                .type(requestDto.getType())
+                .build();
+
+        return userRepository.save(user);
+    }
+
+    @Transactional(readOnly = true)
+    public User findByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+    }
+
+    @Transactional(readOnly = true)
     public UserResponseDto getUser(Long id) {
         User user = findByIdOrFail(id);
 

--- a/src/main/java/com/market/openmarket/domain/user/UserServiceImpl.java
+++ b/src/main/java/com/market/openmarket/domain/user/UserServiceImpl.java
@@ -3,12 +3,23 @@ package com.market.openmarket.domain.user;
 import com.market.openmarket.common.dto.UserResponseDto;
 import com.market.openmarket.common.util.UserValidator;
 import com.market.openmarket.domain.auth.dto.UserSignUpRequestDto;
+import com.market.openmarket.domain.auth.util.bcrypt.PasswordEncoder;
+import com.market.openmarket.domain.user.dto.PasswordResetRequestDto;
 import com.market.openmarket.domain.user.dto.UserUpdateRequestDto;
 import com.market.openmarket.domain.user.entity.User;
 import com.market.openmarket.domain.user.util.email.EmailService;
+import com.market.openmarket.domain.user.util.token.PasswordResetTokenService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +30,10 @@ public class UserServiceImpl implements UserService {
     private final UserValidator userValidator;
 
     private final EmailService emailService;
+
+    private final PasswordEncoder passwordEncoder;
+
+    private final PasswordResetTokenService passwordResetTokenService;
 
     @Transactional(readOnly = true)
     public User findByIdOrFail(Long id) {
@@ -83,11 +98,30 @@ public class UserServiceImpl implements UserService {
         user.setEmail(null);
         user.setNickname(null);
         user.setPhone(null);
-        // TODO: Postgres 의 경우, partial unique index 를 사용하여 해결 가능함.
     }
 
     public void sendPasswordResetEmail(String email) {
         userValidator.checkEmailExists(email);
         emailService.sendPasswordResetEmail(email);
+    }
+
+    @Transactional
+    public void resetPassword(String email, String token, PasswordResetRequestDto requestDto) {
+        String newPwd = requestDto.getNewPwd();
+        String confirmPwd = requestDto.getConfirmPwd();
+        if (!newPwd.equals(confirmPwd)) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        boolean isValid = passwordResetTokenService.validateToken(email, token);
+        if (!isValid) {
+            throw new IllegalArgumentException("유효하지 않은 비밀번호 재설정 요청입니다.");
+        }
+
+        String hashedPwd = passwordEncoder.hash(requestDto.getNewPwd());
+        User user = findByEmailOrFail(email);
+        user.setPwd(hashedPwd);
+
+        passwordResetTokenService.deleteToken(email);
     }
 }

--- a/src/main/java/com/market/openmarket/domain/user/UserServiceImpl.java
+++ b/src/main/java/com/market/openmarket/domain/user/UserServiceImpl.java
@@ -4,22 +4,11 @@ import com.market.openmarket.common.dto.UserResponseDto;
 import com.market.openmarket.common.util.UserValidator;
 import com.market.openmarket.domain.auth.dto.UserSignUpRequestDto;
 import com.market.openmarket.domain.auth.util.bcrypt.PasswordEncoder;
-import com.market.openmarket.domain.user.dto.PasswordResetRequestDto;
 import com.market.openmarket.domain.user.dto.UserUpdateRequestDto;
 import com.market.openmarket.domain.user.entity.User;
-import com.market.openmarket.domain.user.util.email.EmailService;
-import com.market.openmarket.domain.user.util.token.PasswordResetTokenService;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
-
-import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -29,11 +18,7 @@ public class UserServiceImpl implements UserService {
 
     private final UserValidator userValidator;
 
-    private final EmailService emailService;
-
     private final PasswordEncoder passwordEncoder;
-
-    private final PasswordResetTokenService passwordResetTokenService;
 
     @Transactional(readOnly = true)
     public User findByIdOrFail(Long id) {
@@ -100,28 +85,9 @@ public class UserServiceImpl implements UserService {
         user.setPhone(null);
     }
 
-    public void sendPasswordResetEmail(String email) {
-        userValidator.checkEmailExists(email);
-        emailService.sendPasswordResetEmail(email);
-    }
-
     @Transactional
-    public void resetPassword(String email, String token, PasswordResetRequestDto requestDto) {
-        String newPwd = requestDto.getNewPwd();
-        String confirmPwd = requestDto.getConfirmPwd();
-        if (!newPwd.equals(confirmPwd)) {
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
-        }
-
-        boolean isValid = passwordResetTokenService.validateToken(email, token);
-        if (!isValid) {
-            throw new IllegalArgumentException("유효하지 않은 비밀번호 재설정 요청입니다.");
-        }
-
-        String hashedPwd = passwordEncoder.hash(requestDto.getNewPwd());
+    public void updatePassword(String email, String pwd) {
         User user = findByEmailOrFail(email);
-        user.setPwd(hashedPwd);
-
-        passwordResetTokenService.deleteToken(email);
+        user.setPwd(pwd);
     }
 }

--- a/src/main/java/com/market/openmarket/domain/user/UserServiceImpl.java
+++ b/src/main/java/com/market/openmarket/domain/user/UserServiceImpl.java
@@ -44,7 +44,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Transactional(readOnly = true)
-    public User findByEmail(String email) {
+    public User findByEmailOrFail(String email) {
         return userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
     }
@@ -86,11 +86,8 @@ public class UserServiceImpl implements UserService {
         // TODO: Postgres 의 경우, partial unique index 를 사용하여 해결 가능함.
     }
 
-    @Transactional
     public void sendPasswordResetEmail(String email) {
-        userRepository.existsByEmail(email);
-
-        // TODO: 운영환경 주소 변경
+        userValidator.checkEmailExists(email);
         emailService.sendPasswordResetEmail(email);
     }
 }

--- a/src/main/java/com/market/openmarket/domain/user/dto/PasswordFindRequestDto.java
+++ b/src/main/java/com/market/openmarket/domain/user/dto/PasswordFindRequestDto.java
@@ -1,9 +1,11 @@
 package com.market.openmarket.domain.user.dto;
 
+import jakarta.validation.constraints.Email;
 import lombok.Getter;
 
 @Getter
 public class PasswordFindRequestDto {
 
+    @Email
     private String email;
 }

--- a/src/main/java/com/market/openmarket/domain/user/dto/PasswordResetRequestDto.java
+++ b/src/main/java/com/market/openmarket/domain/user/dto/PasswordResetRequestDto.java
@@ -1,0 +1,14 @@
+package com.market.openmarket.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class PasswordResetRequestDto {
+
+    @NotBlank
+    private String newPwd;
+
+    @NotBlank
+    private String confirmPwd;
+}

--- a/src/main/java/com/market/openmarket/domain/user/util/email/EmailService.java
+++ b/src/main/java/com/market/openmarket/domain/user/util/email/EmailService.java
@@ -2,5 +2,5 @@ package com.market.openmarket.domain.user.util.email;
 
 public interface EmailService {
 
-    void sendPasswordResetEmail(String email);
+    void sendPasswordResetEmail(String email, String token);
 }

--- a/src/main/java/com/market/openmarket/domain/user/util/email/EmailServiceImpl.java
+++ b/src/main/java/com/market/openmarket/domain/user/util/email/EmailServiceImpl.java
@@ -1,11 +1,19 @@
 package com.market.openmarket.domain.user.util.email;
 
+import com.market.openmarket.common.config.TokenProperties;
+import com.market.openmarket.domain.auth.JwtToken;
+import com.market.openmarket.domain.auth.util.jwt.JwtProvider;
+import com.market.openmarket.domain.user.util.token.PasswordResetTokenService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.mail.MailException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
@@ -13,18 +21,26 @@ import org.springframework.stereotype.Service;
 public class EmailServiceImpl implements EmailService {
 
     private final JavaMailSender javaMailSender;
+    private final PasswordResetTokenService passwordResetTokenService;
+
+    @Value("${application.url}")
+    private String baseUrl;
 
     public void sendPasswordResetEmail(String email) {
         try {
+            String token = passwordResetTokenService.generatePasswordResetToken(email);
+
+            String resetUrl = baseUrl + "/password-reset?token=" + token;
+
             SimpleMailMessage simpleMailMessage = new SimpleMailMessage();
             simpleMailMessage.setTo(email);
             simpleMailMessage.setSubject("OOPEN MARKET - 비밀번호 찾기");
-            // TODO: setText 내용 수정(버튼으로 등)
-            simpleMailMessage.setText("아래 버튼을 누르면 비밀번호 재설정으로 이동합니다.");
+            simpleMailMessage.setText("아래 링크를 클릭하여 비밀번호를 재설정해주세요. \n" + resetUrl);
 
             javaMailSender.send(simpleMailMessage);
         } catch (MailException e) {
             log.warn(e.getMessage());
+            throw new RuntimeException("이메일 전송에 실패했습니다.");
         }
     }
 }

--- a/src/main/java/com/market/openmarket/domain/user/util/email/EmailServiceImpl.java
+++ b/src/main/java/com/market/openmarket/domain/user/util/email/EmailServiceImpl.java
@@ -1,19 +1,12 @@
 package com.market.openmarket.domain.user.util.email;
 
-import com.market.openmarket.common.config.TokenProperties;
-import com.market.openmarket.domain.auth.JwtToken;
-import com.market.openmarket.domain.auth.util.jwt.JwtProvider;
-import com.market.openmarket.domain.user.util.token.PasswordResetTokenService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.mail.MailException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
-
-import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
@@ -21,15 +14,12 @@ import java.util.concurrent.TimeUnit;
 public class EmailServiceImpl implements EmailService {
 
     private final JavaMailSender javaMailSender;
-    private final PasswordResetTokenService passwordResetTokenService;
 
     @Value("${application.url}")
     private String baseUrl;
 
-    public void sendPasswordResetEmail(String email) {
+    public void sendPasswordResetEmail(String email, String token) {
         try {
-            String token = passwordResetTokenService.generatePasswordResetToken(email);
-
             String resetUrl = baseUrl + "/password-reset?token=" + token;
 
             SimpleMailMessage simpleMailMessage = new SimpleMailMessage();

--- a/src/main/java/com/market/openmarket/domain/user/util/token/PasswordResetTokenService.java
+++ b/src/main/java/com/market/openmarket/domain/user/util/token/PasswordResetTokenService.java
@@ -1,0 +1,58 @@
+package com.market.openmarket.domain.user.util.token;
+
+import com.market.openmarket.common.config.TokenProperties;
+import com.market.openmarket.domain.auth.JwtToken;
+import com.market.openmarket.domain.auth.util.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PasswordResetTokenService {
+
+    private final JwtProvider jwtProvider;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public String generatePasswordResetToken(String email) {
+        JwtToken passwordResetToken = jwtProvider.generatePasswordResetToken(email);
+        String token = passwordResetToken.getToken();
+
+        redisTemplate.opsForValue().set(
+                email,
+                token,
+                TokenProperties.PASSWORD_RESET_EXPIRATION_MINUTES,
+                TimeUnit.MINUTES
+        );
+
+        return token;
+    }
+
+    public boolean validateToken(String email, String token) {
+        String storedToken = redisTemplate.opsForValue().get(email);
+        if (storedToken == null || !storedToken.equals(token)) {
+            return false;
+        }
+
+        try {
+            boolean isValid = jwtProvider.validateToken(token);
+            if (!isValid) {
+                return false;
+            }
+
+            String tokenEmail = jwtProvider.getEmailFromToken(token);
+            return email.equals(tokenEmail);
+        } catch (Exception e) {
+            log.warn("토큰 검증 실패: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    public void deleteToken(String email) {
+        redisTemplate.delete(email);
+    }
+}

--- a/src/test/java/com/market/openmarket/auth/AuthServiceTest.java
+++ b/src/test/java/com/market/openmarket/auth/AuthServiceTest.java
@@ -1,20 +1,19 @@
 package com.market.openmarket.auth;
 
 import com.market.openmarket.common.config.TokenProperties;
+import com.market.openmarket.common.dto.UserResponseDto;
+import com.market.openmarket.common.exception.DuplicateUserException;
 import com.market.openmarket.domain.auth.AuthServiceImpl;
 import com.market.openmarket.domain.auth.JwtToken;
 import com.market.openmarket.domain.auth.RefreshTokenRepository;
 import com.market.openmarket.domain.auth.dto.UserLogInRequestDto;
-import com.market.openmarket.domain.auth.dto.UserSignUpRequestDto;
 import com.market.openmarket.domain.auth.dto.UserLogInResponseDto;
-import com.market.openmarket.common.dto.UserResponseDto;
-import com.market.openmarket.domain.user.entity.User;
-import com.market.openmarket.domain.user.entity.UserType;
-import com.market.openmarket.common.exception.DuplicateUserException;
-import com.market.openmarket.domain.user.UserRepository;
-import com.market.openmarket.common.util.UserValidator;
+import com.market.openmarket.domain.auth.dto.UserSignUpRequestDto;
 import com.market.openmarket.domain.auth.util.bcrypt.PasswordEncoder;
 import com.market.openmarket.domain.auth.util.jwt.JwtProvider;
+import com.market.openmarket.domain.user.UserService;
+import com.market.openmarket.domain.user.entity.User;
+import com.market.openmarket.domain.user.entity.UserType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,29 +25,25 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Date;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
 
     @Mock
-    private UserRepository userRepository;
-
-    @Mock
     private PasswordEncoder passwordEncoder;
-
-    @Mock
-    private UserValidator userValidator;
 
     @Mock
     private JwtProvider jwtProvider;
 
     @Mock
     private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private UserService userService;
 
     @InjectMocks
     private AuthServiceImpl authService;
@@ -92,46 +87,34 @@ class AuthServiceTest {
     void signUp() {
         String hashedPwd = "hashedPassword123";
         when(passwordEncoder.hash(signUpRequestDto.getPwd())).thenReturn(hashedPwd);
-        User savedUser = User.builder()
-                .id(1L)
-                .email(signUpRequestDto.getEmail())
-                .pwd(hashedPwd)
-                .name(signUpRequestDto.getName())
-                .phone(signUpRequestDto.getPhone())
-                .nickname(signUpRequestDto.getNickname())
-                .address(signUpRequestDto.getAddress())
-                .isDeleted(false)
-                .type(signUpRequestDto.getType())
-                .build();
-        when(userRepository.save(any(User.class))).thenReturn(savedUser);
+        when(userService.createUser(any(UserSignUpRequestDto.class))).thenReturn(fakeUser);
 
         UserResponseDto responseDto = authService.signUp(signUpRequestDto);
 
-        assertEquals(1L, responseDto.getId());
-        assertEquals(signUpRequestDto.getEmail(), responseDto.getEmail());
-        assertEquals(signUpRequestDto.getName(), responseDto.getName());
-        assertEquals(signUpRequestDto.getPhone(), responseDto.getPhone());
-        assertEquals(signUpRequestDto.getNickname(), responseDto.getNickname());
-        assertEquals(signUpRequestDto.getAddress(), responseDto.getAddress());
-        assertEquals(signUpRequestDto.getType(), responseDto.getType());
+        assertThat(responseDto.getId()).isEqualTo(fakeUser.getId());
+        assertThat(responseDto.getEmail()).isEqualTo(fakeUser.getEmail());
+        assertThat(responseDto.getName()).isEqualTo(fakeUser.getName());
+        assertThat(responseDto.getPhone()).isEqualTo(fakeUser.getPhone());
+        assertThat(responseDto.getNickname()).isEqualTo(fakeUser.getNickname());
+        assertThat(responseDto.getAddress()).isEqualTo(fakeUser.getAddress());
+        assertThat(responseDto.getType()).isEqualTo(fakeUser.getType());
     }
 
     @Test
     @DisplayName("회원가입 실패 - 이메일 중복")
     void signUpFailed() {
-        doThrow(new DuplicateUserException("Duplicate email")).when(userValidator).validateDuplicate(signUpRequestDto);
+        when(userService.createUser(any(UserSignUpRequestDto.class)))
+                .thenThrow(new DuplicateUserException("이미 사용 중인 이메일입니다."));
 
-        assertThrows(DuplicateUserException.class, () -> {
-            authService.signUp(signUpRequestDto);
-        });
+        assertThatThrownBy(() -> authService.signUp(signUpRequestDto))
+                .isInstanceOf(DuplicateUserException.class);
     }
 
     @Test
     @DisplayName("로그인 성공")
     void logIn() {
-        when(userRepository.findByEmail(logInRequestDto.getEmail()))
-                .thenReturn(Optional.of(fakeUser));
-
+        when(userService.findByEmailOrFail(logInRequestDto.getEmail()))
+                .thenReturn(fakeUser);
         when(passwordEncoder.checkPwd(logInRequestDto.getPwd(), fakeUser.getPwd()))
                 .thenReturn(true);
 
@@ -148,8 +131,8 @@ class AuthServiceTest {
 
         UserLogInResponseDto responseDto = authService.logIn(logInRequestDto);
 
-        assertEquals("access-token", responseDto.getAccessToken());
-        assertEquals("refresh-token", responseDto.getRefreshToken());
+        assertThat("access-token").isEqualTo(responseDto.getAccessToken());
+        assertThat("refresh-token").isEqualTo(responseDto.getRefreshToken());
     }
 
     @Test
@@ -157,11 +140,10 @@ class AuthServiceTest {
     void LogInFailedByNoUser() {
         logInRequestDto.setEmail("wrong@wrong.com");
 
-        when(userRepository.findByEmail(logInRequestDto.getEmail())).thenReturn(Optional.empty());
+        when(userService.findByEmailOrFail(logInRequestDto.getEmail())).thenThrow(new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
-        assertThrows(IllegalArgumentException.class, () -> {
-            authService.logIn(logInRequestDto);
-        });
+        assertThatThrownBy(() -> authService.logIn(logInRequestDto))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -169,11 +151,10 @@ class AuthServiceTest {
     void logInFailedByPwd() {
         logInRequestDto.setPwd("wrong");
 
-        when(userRepository.findByEmail(logInRequestDto.getEmail())).thenReturn(Optional.of(fakeUser));
+        when(userService.findByEmailOrFail(logInRequestDto.getEmail())).thenReturn(fakeUser);
         when(passwordEncoder.checkPwd(logInRequestDto.getPwd(), fakeUser.getPwd())).thenReturn(false);
 
-        assertThrows(IllegalArgumentException.class, () -> {
-            authService.logIn(logInRequestDto);
-        });
+        assertThatThrownBy(() -> authService.logIn(logInRequestDto))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/com/market/openmarket/user/UserServiceTest.java
+++ b/src/test/java/com/market/openmarket/user/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.market.openmarket.user;
 
+import com.market.openmarket.domain.auth.dto.UserSignUpRequestDto;
 import com.market.openmarket.domain.user.UserRepository;
 import com.market.openmarket.domain.user.UserServiceImpl;
 import com.market.openmarket.domain.user.dto.UserUpdateRequestDto;
@@ -18,6 +19,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -34,6 +37,7 @@ class UserServiceTest {
     private UserServiceImpl userService;
 
     private User fakeUser;
+    private UserSignUpRequestDto signUpRequestDto;
 
     @BeforeEach
     void setUp() {
@@ -48,30 +52,102 @@ class UserServiceTest {
                 .isDeleted(false)
                 .type(UserType.CUSTOMER)
                 .build();
+
+        signUpRequestDto = UserSignUpRequestDto.builder()
+                .email("test@test.com")
+                .pwd("1234")
+                .build();
     }
 
     @Test
-    @DisplayName("유저를 id로 찾는다.")
+    @DisplayName("유저를 id 로 조회한다.")
+    void findByIdOrFail() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(fakeUser));
+
+        User user = userService.findByIdOrFail(1L);
+
+        assertThat(user.getId()).isEqualTo(fakeUser.getId());
+        assertThat(user.getEmail()).isEqualTo(fakeUser.getEmail());
+        assertThat(user.getName()).isEqualTo(fakeUser.getName());
+        assertThat(user.getPhone()).isEqualTo(fakeUser.getPhone());
+        assertThat(user.getNickname()).isEqualTo(fakeUser.getNickname());
+        assertThat(user.getAddress()).isEqualTo(fakeUser.getAddress());
+    }
+
+    @Test
+    @DisplayName("유저를 id 로 조회하기에 실패한다.")
+    void findByIdOrFailFailed() {
+        when(userRepository.findById(1L)).thenThrow(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> userService.findByIdOrFail(1L))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("유저를 이메일로 조회한다.")
+    void findByEmailOrFail() {
+        when(userRepository.findByEmail("test@test.com")).thenReturn(Optional.of(fakeUser));
+        User user = userService.findByEmailOrFail("test@test.com");
+
+        assertThat(user.getId()).isEqualTo(fakeUser.getId());
+    }
+
+    @Test
+    @DisplayName("유저를 이메일로 조회하기에 실패한다.")
+    void findByEmailOrFailFailed() {
+        when(userRepository.findByEmail("wrong@test.com")).thenThrow(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> userService.findByEmailOrFail("wrong@test.com"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("유저 정보를 가져온다.")
     void getUser() {
         when(userRepository.findById(1L)).thenReturn(Optional.of(fakeUser));
         UserResponseDto responseDto = userService.getUser(1L);
 
-        assertEquals(fakeUser.getId(), responseDto.getId());
-        assertEquals(fakeUser.getEmail(), responseDto.getEmail());
-        assertEquals(fakeUser.getName(), responseDto.getName());
-        assertEquals(fakeUser.getPhone(), responseDto.getPhone());
-        assertEquals(fakeUser.getNickname(), responseDto.getNickname());
-        assertEquals(fakeUser.getAddress(), responseDto.getAddress());
+        assertThat(fakeUser.getId()).isEqualTo(responseDto.getId());
+        assertThat(fakeUser.getEmail()).isEqualTo(responseDto.getEmail());
+        assertThat(fakeUser.getName()).isEqualTo(responseDto.getName());
+        assertThat(fakeUser.getPhone()).isEqualTo(responseDto.getPhone());
+        assertThat(fakeUser.getNickname()).isEqualTo(responseDto.getNickname());
+        assertThat(fakeUser.getAddress()).isEqualTo(responseDto.getAddress());
     }
 
     @Test
-    @DisplayName("유저를 id로 찾는데 실패한다.")
+    @DisplayName("유저 정보를 가져오기에 실패한다.")
     void getUserFailed() {
         when(userRepository.findById(1L)).thenThrow(IllegalArgumentException.class);
 
-        assertThrows(IllegalArgumentException.class, () -> {
-            userService.getUser(1L);
-        });
+        assertThatThrownBy(() -> userService.getUser(1L))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("회원 생성에 성공한다.")
+    void createUser() {
+        doNothing().when(userValidator).validateDuplicate(signUpRequestDto);
+        when(userRepository.save(any(User.class))).thenReturn(fakeUser);
+
+        User user = userService.createUser(signUpRequestDto);
+
+        assertThat(user.getId()).isEqualTo(fakeUser.getId());
+        assertThat(user.getEmail()).isEqualTo(fakeUser.getEmail());
+        assertThat(user.getName()).isEqualTo(fakeUser.getName());
+        assertThat(user.getPhone()).isEqualTo(fakeUser.getPhone());
+        assertThat(user.getNickname()).isEqualTo(fakeUser.getNickname());
+        assertThat(user.getAddress()).isEqualTo(fakeUser.getAddress());
+        assertThat(user.getType()).isEqualTo(fakeUser.getType());
+    }
+
+    @Test
+    @DisplayName("회원 생성에 실패 - 중복된 정보")
+    void createUserFailedByDuplicatedEmail() {
+        doThrow(DuplicateUserException.class).when(userValidator).validateDuplicate(signUpRequestDto);
+
+        assertThatThrownBy(() -> userService.createUser(signUpRequestDto))
+                .isInstanceOf(DuplicateUserException.class);
     }
 
     @Test
@@ -87,9 +163,9 @@ class UserServiceTest {
 
         UserResponseDto responseDto = userService.updateUser(1L, requestDto);
 
-        assertEquals("koko", responseDto.getNickname());
-        assertEquals("010-2345-3456", responseDto.getPhone());
-        assertEquals("changed-address", responseDto.getAddress());
+        assertThat(responseDto.getNickname()).isEqualTo("koko");
+        assertThat(responseDto.getPhone()).isEqualTo("010-2345-3456");
+        assertThat(responseDto.getAddress()).isEqualTo("changed-address");
     }
 
     @Test
@@ -102,8 +178,8 @@ class UserServiceTest {
         when(userRepository.findById(1L)).thenReturn(Optional.of(fakeUser));
         doThrow(DuplicateUserException.class).when(userValidator).validateDuplicateForUpdate(1L, updateDto);
 
-        assertThrows(DuplicateUserException.class, () ->
-                userService.updateUser(1L, updateDto));
+        assertThatThrownBy(() -> userService.updateUser(1L, updateDto))
+                .isInstanceOf(DuplicateUserException.class);
     }
 
     @Test
@@ -116,8 +192,8 @@ class UserServiceTest {
         when(userRepository.findById(1L)).thenReturn(Optional.of(fakeUser));
         doThrow(DuplicateUserException.class).when(userValidator).validateDuplicateForUpdate(1L, updateDto);
 
-        assertThrows(DuplicateUserException.class, () ->
-                userService.updateUser(1L, updateDto));
+        assertThatThrownBy(() -> userService.updateUser(1L, updateDto))
+                .isInstanceOf(DuplicateUserException.class);
     }
 
     @Test
@@ -137,8 +213,7 @@ class UserServiceTest {
     void deleteUserFailed() {
         when(userRepository.findById(1L)).thenThrow(IllegalArgumentException.class);
 
-        assertThrows(IllegalArgumentException.class, () -> {
-            userService.deleteUser(1L);
-        });
+        assertThatThrownBy(() -> userService.deleteUser(1L))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }


### PR DESCRIPTION
1. jwt 을 비밀번호 재설정 이메일에 담았습니다. 해당 토큰으로 시간이 오래 지났는지, 요청자 email과 토큰이 일치하는지 검사하고 비밀번호를 재설정합니다.
2. TokenService 클래스로 비밀번호 찾기/리셋에 필요한 부분들을 JwtProvider에서 분리하였습니다. 이로서 JwtProvider 는 더욱 단순명료하게 토큰 발급/검증/값 가져오기(지금은 서브젝트만, 필요 시 추가예정) 을 하고 더욱 구체적인 구현은 토큰서비스에서 진행됩니다. 토큰서비스가 프로바이더를 의존합니다.
3. 회원가입/로그인과 마찬가지로 비밀번호 찾기 메일 발송/리셋의 책임을 분리하였습니다. 토큰을 사용하는 인증 인가 관련은 authService로, 유저의 정보를 수정하는 리셋은 userService로 나눴습니다.
4. authService가 tokenService의 구현체를 의존하고있어 인터페이스를 작성하였습니다.